### PR TITLE
LIBWEB-6498: Updates to match LIT conventions

### DIFF
--- a/lit/src/umd/search-result-element-umd-libraries.ts
+++ b/lit/src/umd/search-result-element-umd-libraries.ts
@@ -1,7 +1,11 @@
 import { html, nothing } from 'lit';
 import { property, customElement } from 'lit/decorators.js';
 import { BaseSearchElement } from '../BaseSearchElement';
-import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+
+interface Field {
+  key: string;
+  show_label?: string;
+}
 
 /**
  * A default result render element that shows the raw JSON for each result in a collapsible details element.
@@ -13,7 +17,7 @@ export class SearchResultElementUMDLibraries extends BaseSearchElement {
    * The settings for this element type.
    * This
    */
-  @property({type: Object})
+  @property({ type: Object })
   settings: {
     field?: string;
     [key: string]: any;
@@ -26,18 +30,27 @@ export class SearchResultElementUMDLibraries extends BaseSearchElement {
   data: Record<string, any> = {};
 
   override render() {
-    type result_fields = keyof typeof this.data;
 
-    const id_field = this.settings['id'] as result_fields;
-    const title_field = this.settings['title'] as result_fields;
-    const thumbnail_field = this.settings['thumbnail'] as result_fields;
-    const fields = this.settings['fields'];
+    const id_field = this.settings['id'] as string;
+    const title_field = this.settings['title'] as string;
+    const thumbnail_field = this.settings['thumbnail'] as string;
+    const fields: Record<string, Field> = this.settings['fields'];
     const base_path: string = this.settings['base_path'];
 
-    let id = this.data[id_field];
+    const query_string = this?.context?.query?.get('q');
+    let id = this.data[id_field].replace("solr_document/");
+    id = query_string ? id + "?q=" + query_string : id;
+
     let title = this.data[title_field];
     let thumbnail = this.data[thumbnail_field]
-    let field_output = ''
+
+    const field_list = Object.entries(fields).map(([label, field]) => {
+      if (field.show_label && field.show_label == "true") {
+        return html`<li> <strong> ${label}:</strong> ${this.data[field.key]} </li>`
+      } else {
+        return html`<li> ${this.data[field.key]} </li>`
+      }
+    });
 
     if (Array.isArray(title)) {
       title = title.map((t: string) => t.startsWith('[@') ? t.split(']')[1] : t);
@@ -48,38 +61,16 @@ export class SearchResultElementUMDLibraries extends BaseSearchElement {
       thumbnail = thumbnail[0];
     }
 
-    for(var key in fields) {
-      if (fields.hasOwnProperty(key)) {
-        let displayed_field = fields[key].key
-        let show_label = fields[key].show_label
-        if (this.data[displayed_field]) {
-          if (show_label && show_label == "true") {
-            field_output += '<li><strong>' + key + ':</strong> ' + this.data[displayed_field] + '</li>'
-          } else {
-            field_output += '<li>' + this.data[displayed_field] + '</li>'
-          }
-        }
-      }
-    }
-
-    let revised_id = id.replace("solr_document/")
-
-    let query_string = this?.context?.query?.get('q')
-
-    if (query_string) {
-      revised_id += "?q=" + query_string
-    }
-
     return html`
       <h2>
-        <a href="${base_path + revised_id}">
+        <a href="${base_path + id}">
           ${title}
         </a>
       </h2>
 
-      ${ thumbnail === 'static:unavailable' ? nothing : html`<img src="${thumbnail}" />` }
+      ${thumbnail === 'static:unavailable' ? nothing : html`<img src="${thumbnail}" />`}
 
-      ${ html`<ul> ${unsafeHTML(field_output)} </ul>` }
+      ${html`<ul> ${field_list} </ul>`}
       <hr />
     `;
   }


### PR DESCRIPTION
Rather than construct a string with html attributes and use unsafeHTML, we can just create a list of html templates, and when we provide that to the render, LIT will handle extracting the elements from the list.

Ultimately we'll end up with the same result!
Lit docs: https://lit.dev/docs/templates/lists/

Also to make what types we're working with from the settings more clear, I created an interface for the fields. This helps with the syntax highlighting.

https://umd-dit.atlassian.net/browse/LIBWEB-6498