### PR TITLE
LIBWEB-6494: Use POST method for Search API Requests

### DIFF
--- a/lit/src/BaseSearchElement.ts
+++ b/lit/src/BaseSearchElement.ts
@@ -46,7 +46,7 @@ export class BaseSearchElement extends LitElement {
 
     query.delete('page');
 
-    this.getResults(query);
+    this.getResults(query, 'POST');
   }
 
   clearFacet(key: string) {
@@ -56,7 +56,7 @@ export class BaseSearchElement extends LitElement {
     query.delete(queryKey);
     query.delete('page');
 
-    this.getResults(query);
+    this.getResults(query, 'POST');
   }
 
   clearFacets() {
@@ -75,7 +75,7 @@ export class BaseSearchElement extends LitElement {
       query.delete('page');
     }
 
-    this.getResults(query);
+    this.getResults(query, 'POST');
   }
 
   async getResults(query: URLSearchParams, method: 'GET' | 'POST' = 'GET') {

--- a/lit/src/search-box/search-box.ts
+++ b/lit/src/search-box/search-box.ts
@@ -1,11 +1,12 @@
-import {html, LitElement} from 'lit';
+import {html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
+import {BaseSearchElement} from '../BaseSearchElement';
 
 /**
  * A simple search box that can be placed in the header or other parts of a site to allow a user to search and be redirected to a search page.
  */
 @customElement('search-box')
-export class SearchBox extends LitElement {
+export class SearchBox extends BaseSearchElement {
   /**
    * The absolute or relative url of the page to redirect the search query to.
    */
@@ -42,7 +43,7 @@ export class SearchBox extends LitElement {
   }
 
   /**
-   * Handles redirecting the user to the correct page on form submission.
+   * Customized submit to submit POST requests to the api endpoint with the query.
    *
    * @param e The form submit event.
    */
@@ -50,11 +51,12 @@ export class SearchBox extends LitElement {
     e.preventDefault();
 
     if (e.currentTarget instanceof Element) {
-      window.location.replace(
-        this.url +
-          '?q=' +
-          e?.currentTarget?.querySelector('input')?.value?.trim()
-      );
+      const value = e?.currentTarget?.querySelector('input')?.value?.trim();
+
+      const query = new URLSearchParams();
+      query.set('q', value || '');
+
+      this.getResults(query, 'POST');
     }
   }
 

--- a/lit/src/search-simple-pager/search-simple-pager.ts
+++ b/lit/src/search-simple-pager/search-simple-pager.ts
@@ -70,7 +70,7 @@ export class SearchSimplePager extends BaseSearchElement {
       query.delete('page');
     }
 
-    this.getResults(query);
+    this.getResults(query, 'POST');
   }
 
   /**


### PR DESCRIPTION
Makes the search box, pager, and facets use POST for Search API requests

The Search Box had to be modified more to make POST requests, by subclassing the BaseSearchElement and updating the event it makes when a search is submitted.

https://umd-dit.atlassian.net/browse/LIBWEB-6494